### PR TITLE
Add ability to update "Back-Half" of the bitlink

### DIFF
--- a/lib/PHPLicengine/Api/Api.php
+++ b/lib/PHPLicengine/Api/Api.php
@@ -124,7 +124,7 @@ class Api implements ApiInterface {
                      } 
                      switch (strtoupper($method)) { 
                             case 'PATCH':
-                                          curl_setopt(/** @scrutinizer ignore-type */ $ch, CURLOPT_PATCH, true);
+                                          curl_setopt(/** @scrutinizer ignore-type */ $ch, CURLOPT_CUSTOMREQUEST, 'PATCH');
                                           
                                           if (!empty($params)) {
                                               curl_setopt(/** @scrutinizer ignore-type */ $ch, CURLOPT_POSTFIELDS, json_encode($params));

--- a/lib/PHPLicengine/Service/Bitlink.php
+++ b/lib/PHPLicengine/Service/Bitlink.php
@@ -171,5 +171,13 @@ class Bitlink {
       {
              return $this->api->patch($this->url . '/groups/'.$group_guid.'/bitlinks', $params);
       }
- 
+
+      /*
+      Customize a Bitlink
+      https://dev.bitly.com/api-reference#addCustomBitlink
+      */
+      public function customizeBackHalf(string $custom_url, array $params)
+      {
+          return $this->api->patch($this->url . '/custom_bitlinks/' . $custom_url, $params);
+      }
 }


### PR DESCRIPTION
I want to be able to make a custom link on bit.ly without going through the UI.

These changes were necessary to make it work.